### PR TITLE
fix references of 86Box to PCBox in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# 86Box ROM repository
+# PCBox ROM repository
 
-This repository contains all ROMs needed by the [86Box](https://github.com/86Box/86Box) emulator. For development versions of 86Box, the recommended way to use this repository is to clone it instead of downloading the tagged releases.
+This repository contains all ROMs needed by the [PCBox](https://github.com/PCBox/PCBox) emulator. For development versions of PCBox, the recommended way to use this repository is to clone it instead of downloading the tagged releases.
 
-Note that some ROMs in this repository may be for dev-branched machines and devices, meaning that they will not do anything on regular release builds. If you are confused why some device does not appear despite the ROM being present in the set, check that you are using an appropriate build of 86Box before reporting issues.
+Note that some ROMs in this repository may be for dev-branched machines and devices, meaning that they will not do anything on regular release builds. If you are confused why some device does not appear despite the ROM being present in the set, check that you are using an appropriate build of PCBox before reporting issues.
 
 ## Contributing ROMs
-Before new ROMs can be accepted in this repository, the code that uses the ROMs needs to be in the upstream 86Box repository. Once you've made an 86Box pull request, open a pull request here. This applies to removals as well in inverse. 
+Before new ROMs can be accepted in this repository, the code that uses the ROMs needs to be in the upstream PCBox repository. Once you've made an PCBox pull request, open a pull request here. This applies to removals as well in inverse. 
 
-Note that your ROM(s) will not be merged to master until the code is in 86Box master. However, if the development is happening in an upstream 86Box branch, a corresponding branch can be created here until the feature is ready for master.
+Note that your ROM(s) will not be merged to master until the code is in PCBox master. However, if the development is happening in an upstream PCBox branch, a corresponding branch can be created here until the feature is ready for master.
 
 ## Committing guidelines
 - Do not use vague commit messages.


### PR DESCRIPTION
# Description:

fix references of 86Box to PCBox in README

# Checklist:
- [N/A] I have opened a pull request in the main 86Box repository.
- [x] I have not added any unrelated files to this pull request.
- [x] My commit(s) follow the [committing guidelines](https://github.com/86Box/roms#committing-guidelines).

# Your 86Box pull request:
N/A
